### PR TITLE
swap order of ideals, fix kernels and cokernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,26 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "const_format"
-version = "0.2.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c990efc7a285731f9a4378d81aff2f0e85a2c8781a05ef0f8baa8dac54d0ff48"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e026b6ce194a874cb9cf32cd5772d1ef9767cc8fcb5765948d74f37a9d8b2bf6"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-xid",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,24 +127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "quote"
-version = "1.0.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
-dependencies = [
- "proc-macro2",
-]
-
-[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,7 +165,6 @@ name = "szymczak_leray"
 version = "0.1.0"
 dependencies = [
  "bitvec",
- "const_format",
  "dedup",
  "itertools",
  "rayon",
@@ -221,18 +182,6 @@ name = "typenum"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
-
-[[package]]
-name = "unicode-ident"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "wyz"

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,11 +116,11 @@ use crate::{
 };
 use std::time::Instant;
 // parameters for the code
-use typenum::U25 as N;
+use typenum::U4 as N;
 type Int = u16;
 type R = C<N>;
 type I = CIdeal<N>;
-const DIM: Int = 1;
+const DIM: Int = 2;
 const RECURSION_PARAMETER: usize = 6;
 
 fn main() {

--- a/src/ralg/module/canon/element.rs
+++ b/src/ralg/module/canon/element.rs
@@ -179,15 +179,15 @@ mod test {
     #[test]
     fn equality() {
         type N = U6;
-        let z6xz3 =
+        let z223 =
             Object::<C<N>, CIdeal<N>>::from_iter([0, 3].map(|j| CIdeal::principal(C::from(j))));
-        let z6sq =
+        let z2233 =
             Object::<C<N>, CIdeal<N>>::from_iter([0, 0].map(|j| CIdeal::principal(C::from(j))));
 
-        let a = z6xz3.element_from_iterator([1, 1, 1].into_iter().map(C::from));
-        let b = z6xz3.element_from_iterator([2, 1, 1].into_iter().map(C::from));
-        let c = z6xz3.element_from_iterator([4, 1, 1].into_iter().map(C::from));
-        let d = z6sq.element_from_iterator([1, 1, 1, 0].into_iter().map(C::from));
+        let a = z223.element_from_iterator([1, 1, 1].into_iter().map(C::from));
+        let b = z223.element_from_iterator([1, 1, 2].into_iter().map(C::from));
+        let c = z223.element_from_iterator([1, 1, 4].into_iter().map(C::from));
+        let d = z2233.element_from_iterator([1, 1, 1, 0].into_iter().map(C::from));
         assert_eq!(a.is_equal(&b), Some(false));
         assert_eq!(a.is_equal(&c), Some(true));
         assert_eq!(a.is_equal(&d), None);
@@ -197,18 +197,18 @@ mod test {
     #[allow(clippy::shadow_unrelated, reason = "useful in test")]
     fn addition() {
         type N = U6;
-        let z6xz3 =
+        let z223 =
             Object::<C<N>, CIdeal<N>>::from_iter([0, 3].map(|j| CIdeal::principal(C::from(j))));
 
-        let a = z6xz3.element_from_iterator([1, 1, 1].into_iter().map(C::from));
-        let b = z6xz3.element_from_iterator([2, 1, 1].into_iter().map(C::from));
-        let c = z6xz3.element_from_iterator([0, 2, 0].into_iter().map(C::from));
+        let a = z223.element_from_iterator([1, 1, 1].into_iter().map(C::from));
+        let b = z223.element_from_iterator([1, 0, 2].into_iter().map(C::from));
+        let c = z223.element_from_iterator([0, 1, 0].into_iter().map(C::from));
         assert_eq!(
             a.try_add(b.clone()).and_then(|e| e.is_equal(&c)),
             Some(true)
         );
 
-        let a = z6xz3.element_from_iterator([4, 7, 3].into_iter().map(C::from));
+        let a = z223.element_from_iterator([3, 7, 4].into_iter().map(C::from));
         assert_eq!(
             a.try_add(b.clone()).and_then(|e| e.is_equal(&c)),
             Some(true)

--- a/src/ralg/module/canon/mark.rs
+++ b/src/ralg/module/canon/mark.rs
@@ -1,13 +1,10 @@
-use std::{
-    cmp,
-    sync::atomic::{AtomicU64, Ordering},
-};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /* # element with UUID */
 
 static COUNTER: AtomicU64 = AtomicU64::new(0);
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Mark<T> {
     pub thing: T,
     index: u64,
@@ -62,29 +59,3 @@ impl<T> Mark<Option<T>> {
 
 unsafe impl<T: Send> Send for Mark<T> {}
 unsafe impl<T: Sync> Sync for Mark<T> {}
-
-/* ## order */
-
-impl<T: PartialOrd> PartialOrd for Mark<T> {
-    /// lexicographic order, reversed on thing
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        match (
-            self.thing.partial_cmp(&other.thing),
-            self.index.partial_cmp(&other.index),
-        ) {
-            (None, _) => None,
-            (Some(cmp::Ordering::Equal), ord) => ord,
-            (Some(ord), _) => Some(ord.reverse()),
-        }
-    }
-}
-
-impl<T: Ord> Ord for Mark<T> {
-    /// lexicographic order, reversed on thing
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        match (self.thing.cmp(&other.thing), self.index.cmp(&other.index)) {
-            (cmp::Ordering::Equal, ord) => ord,
-            (ord, _) => ord.reverse(),
-        }
-    }
-}

--- a/src/ralg/module/canon/object.rs
+++ b/src/ralg/module/canon/object.rs
@@ -471,12 +471,12 @@ mod test {
             .buffer
             .iter()
             .map(|x| u16::from(x.thing.ideal.generator()));
+        assert_eq!(marks.next(), Some(2));
+        assert_eq!(marks.next(), Some(2));
+        assert_eq!(marks.next(), Some(2));
+        assert_eq!(marks.next(), Some(2));
         assert_eq!(marks.next(), Some(3));
         assert_eq!(marks.next(), Some(3));
-        assert_eq!(marks.next(), Some(2));
-        assert_eq!(marks.next(), Some(2));
-        assert_eq!(marks.next(), Some(2));
-        assert_eq!(marks.next(), Some(2));
         assert_eq!(marks.next(), None);
     }
 
@@ -490,9 +490,9 @@ mod test {
             .buffer
             .iter()
             .map(|x| u16::from(x.thing.ideal.generator()));
-        assert_eq!(marks.next(), Some(4));
-        assert_eq!(marks.next(), Some(3));
         assert_eq!(marks.next(), Some(2));
+        assert_eq!(marks.next(), Some(3));
+        assert_eq!(marks.next(), Some(4));
         assert_eq!(marks.next(), None);
     }
 
@@ -509,17 +509,17 @@ mod test {
             .buffer
             .iter()
             .map(|x| u16::from(x.thing.ideal.generator()));
-        assert_eq!(marks_left.next(), Some(32));
-        assert_eq!(marks_left.next(), Some(8));
         assert_eq!(marks_left.next(), Some(2));
+        assert_eq!(marks_left.next(), Some(8));
+        assert_eq!(marks_left.next(), Some(32));
         assert_eq!(marks_left.next(), None);
 
         let mut marks_right = r
             .buffer
             .iter()
             .map(|x| u16::from(x.thing.ideal.generator()));
-        assert_eq!(marks_right.next(), Some(16));
         assert_eq!(marks_right.next(), Some(4));
+        assert_eq!(marks_right.next(), Some(16));
         assert_eq!(marks_right.next(), None);
     }
 
@@ -536,11 +536,11 @@ mod test {
             .buffer
             .iter()
             .map(|x| u16::from(x.thing.ideal.generator()));
+        assert_eq!(marks.next(), Some(2));
+        assert_eq!(marks.next(), Some(2));
+        assert_eq!(marks.next(), Some(3));
+        assert_eq!(marks.next(), Some(3));
         assert_eq!(marks.next(), Some(4));
-        assert_eq!(marks.next(), Some(3));
-        assert_eq!(marks.next(), Some(3));
-        assert_eq!(marks.next(), Some(2));
-        assert_eq!(marks.next(), Some(2));
         assert_eq!(marks.next(), None);
     }
 
@@ -691,46 +691,46 @@ mod test {
     fn submodules_of_Z2xZ4() {
         type R = C<U4>;
         type I = CIdeal<U4>;
-        let z42 = Arc::new(Object::<R, I>::from_iter([4, 2]));
-        let submodules = (*z42).clone().submodules();
+        let z24 = Arc::new(Object::<R, I>::from_iter([4, 2]));
+        let submodules = (*z24).clone().submodules();
 
         let trivial = CanonToCanon::new(
             &Arc::new(Object::from_iter([1])),
-            &z42,
+            &z24,
             Matrix::from_buffer([], 0, 2),
         );
         assert!(submodules.contains(&trivial), "trivial submodule");
 
         let right_z2 = CanonToCanon::new(
             &Arc::new(Object::from_iter([2])),
-            &z42,
-            Matrix::from_buffer([0, 1].map(R::from), 1, 2),
+            &z24,
+            Matrix::from_buffer([0, 2].map(R::from), 1, 2),
         );
         assert!(submodules.contains(&right_z2), "right Z2");
 
         let left_z2 = CanonToCanon::new(
             &Arc::new(Object::from_iter([2])),
-            &z42,
-            Matrix::from_buffer([2, 0].map(R::from), 1, 2),
+            &z24,
+            Matrix::from_buffer([1, 0].map(R::from), 1, 2),
         );
         assert!(submodules.contains(&left_z2), "left Z2");
 
         let diagonal_z2 = CanonToCanon::new(
             &Arc::new(Object::from_iter([2])),
-            &z42,
-            Matrix::from_buffer([2, 1].map(R::from), 1, 2),
+            &z24,
+            Matrix::from_buffer([1, 2].map(R::from), 1, 2),
         );
         assert!(submodules.contains(&diagonal_z2), "diagonal Z2");
 
         let z2sq_a = CanonToCanon::new(
             &Arc::new(Object::from_iter([2, 2])),
-            &z42,
-            Matrix::from_buffer([2, 0, 0, 1].map(R::from), 2, 2),
+            &z24,
+            Matrix::from_buffer([1, 0, 0, 2].map(R::from), 2, 2),
         );
         let z2sq_b = CanonToCanon::new(
             &Arc::new(Object::from_iter([2, 2])),
-            &z42,
-            Matrix::from_buffer([0, 2, 1, 0].map(R::from), 2, 2),
+            &z24,
+            Matrix::from_buffer([0, 1, 2, 0].map(R::from), 2, 2),
         );
         assert!(
             submodules.contains(&z2sq_a) || submodules.contains(&z2sq_b),
@@ -739,34 +739,21 @@ mod test {
 
         let straight_z4 = CanonToCanon::new(
             &Arc::new(Object::from_iter([4])),
-            &z42,
-            Matrix::from_buffer([1, 0].map(R::from), 1, 2),
+            &z24,
+            Matrix::from_buffer([0, 1].map(R::from), 1, 2),
         );
         assert!(submodules.contains(&straight_z4), "straight Z4");
 
-        /*
-        this does not work due to a small inconsistency i found
-        the result still provides the right elements of the group, just in the wrong configuration
-        this is attested by the `kernel_asymetric` test that fails
-        */
-        let proper_diagonal_z4 = CanonToCanon::new(
+        let diagonal_z4 = CanonToCanon::new(
             &Arc::new(Object::from_iter([4])),
-            &z42,
+            &z24,
             Matrix::from_buffer([1, 1].map(R::from), 1, 2),
         );
-        let fake_diagonal_z4 = CanonToCanon::new(
-            &Arc::new(Object::from_iter([2, 2])),
-            &z42,
-            Matrix::from_buffer([2, 1, 0, 1].map(R::from), 2, 2),
-        );
-        assert!(
-            submodules.contains(&proper_diagonal_z4) || submodules.contains(&fake_diagonal_z4),
-            "diagonal Z4"
-        );
+        assert!(submodules.contains(&diagonal_z4), "diagonal Z4");
 
         let full = CanonToCanon::new(
             &Arc::new(Object::from_iter([4, 2])),
-            &z42,
+            &z24,
             Matrix::from_buffer([1, 0, 0, 1].map(R::from), 2, 2),
         );
         assert!(submodules.contains(&full), "full submodule");
@@ -908,21 +895,6 @@ mod test {
             8,
             "there should be 1 + 3 + 3 + 1 = 8 subgroups"
         );
-
-        for module in submodules.iter().combinations(2) {
-            assert_ne!(module.get(0), module.get(1));
-        }
-    }
-
-    #[test]
-    fn submodules_of_Z2xZ4xZ8() {
-        type R = C<U8>;
-        type I = CIdeal<U8>;
-
-        let z = Object::<R, I>::from_iter([2, 4, 8]);
-        let submodules: Vec<CanonToCanon<R, I>> = z.submodules();
-
-        assert_eq!(submodules.len(), 86, "there should be 86 subgroups");
 
         for module in submodules.iter().combinations(2) {
             assert_ne!(module.get(0), module.get(1));

--- a/src/ralg/module/direct.rs
+++ b/src/ralg/module/direct.rs
@@ -335,17 +335,17 @@ mod test {
         let z2 = Arc::new(CanonModule::<R, I>::from_iter([2]));
         let z3 = Arc::new(CanonModule::<R, I>::from_iter([3]));
         let z4 = Arc::new(CanonModule::<R, I>::from_iter([4]));
-        let z43_canon = Arc::new(CanonModule::<R, I>::from_iter([4, 3]));
-        let z43_direct = Object::sumproduct(&z4, &z3);
+        let z34_canon = Arc::new(CanonModule::<R, I>::from_iter([3, 4]));
+        let z34_direct = Object::sumproduct(&z3, &z4);
         assert_eq!(
-            z43_direct.universal_in(
-                &CanonToCanon::new(&z2, &z4, Matrix::from_buffer([2, 0].map(R::from), 1, 2)),
+            z34_direct.universal_in(
                 &CanonToCanon::new(&z2, &z3, Matrix::from_buffer([0].map(R::from), 1, 1)),
+                &CanonToCanon::new(&z2, &z4, Matrix::from_buffer([2].map(R::from), 1, 1)),
             ),
             CanonToCanon::new(
                 &z2,
-                &z43_canon,
-                Matrix::from_buffer([2, 0].map(R::from), 1, 2),
+                &z34_canon,
+                Matrix::from_buffer([0, 2].map(R::from), 1, 2),
             )
         );
     }
@@ -354,31 +354,31 @@ mod test {
     fn universal_morphism_in_medium() {
         type R = C<U12>;
         type I = CIdeal<U12>;
-        let z43 = Arc::new(CanonModule::<R, I>::from_iter([4, 3]));
-        let z32 = Arc::new(CanonModule::<R, I>::from_iter([3, 2]));
-        let z4332_canon = Arc::new(CanonModule::<R, I>::from_iter([4, 3, 3, 2]));
-        let z4332_direct = Object::sumproduct(&z32, &z43);
-        let univ_in = z4332_direct.universal_in(
+        let z34 = Arc::new(CanonModule::<R, I>::from_iter([4, 3]));
+        let z23 = Arc::new(CanonModule::<R, I>::from_iter([3, 2]));
+        let z2334_canon = Arc::new(CanonModule::<R, I>::from_iter([4, 3, 3, 2]));
+        let z2334_direct = Object::sumproduct(&z23, &z34);
+        let univ_in = z2334_direct.universal_in(
             &CanonToCanon::new(
-                &z43,
-                &z32,
-                Matrix::from_buffer([0, 2, 1, 0].map(R::from), 2, 2),
+                &z34,
+                &z23,
+                Matrix::from_buffer([0, 1, 2, 0].map(R::from), 2, 2),
             ),
             &CanonToCanon::new(
-                &z43,
-                &z43,
-                Matrix::from_buffer([2, 0, 0, 1].map(R::from), 2, 2),
+                &z34,
+                &z34,
+                Matrix::from_buffer([1, 0, 0, 2].map(R::from), 2, 2),
             ),
         );
         let true_output_a = CanonToCanon::new(
-            &z43,
-            &z4332_canon,
-            Matrix::from_buffer([2, 0, 0, 1, 0, 2, 1, 0].map(R::from), 2, 4),
+            &z34,
+            &z2334_canon,
+            Matrix::from_buffer([1, 0, 0, 1, 2, 0, 0, 2].map(R::from), 2, 4),
         );
         let true_output_b = CanonToCanon::new(
-            &z43,
-            &z4332_canon,
-            Matrix::from_buffer([2, 0, 0, 2, 0, 1, 1, 0].map(R::from), 2, 4),
+            &z34,
+            &z2334_canon,
+            Matrix::from_buffer([0, 1, 1, 0, 2, 0, 0, 2].map(R::from), 2, 4),
         );
         // due to random id, one of those will be true
         assert!(univ_in == true_output_a || univ_in == true_output_b,);
@@ -391,17 +391,17 @@ mod test {
         let z2 = Arc::new(CanonModule::<R, I>::from_iter([2]));
         let z3 = Arc::new(CanonModule::<R, I>::from_iter([3]));
         let z4 = Arc::new(CanonModule::<R, I>::from_iter([4]));
-        let z43_canon = Arc::new(CanonModule::<R, I>::from_iter([4, 3]));
-        let z43_direct = Object::sumproduct(&z4, &z3);
+        let z34_canon = Arc::new(CanonModule::<R, I>::from_iter([4, 3]));
+        let z34_direct = Object::sumproduct(&z3, &z4);
         assert_eq!(
-            z43_direct.universal_out(
-                &CanonToCanon::new(&z4, &z2, Matrix::from_buffer([1, 0].map(R::from), 1, 2)),
+            z34_direct.universal_out(
                 &CanonToCanon::new(&z3, &z2, Matrix::from_buffer([0].map(R::from), 1, 1)),
+                &CanonToCanon::new(&z4, &z2, Matrix::from_buffer([1].map(R::from), 1, 1)),
             ),
             CanonToCanon::new(
-                &z43_canon,
+                &z34_canon,
                 &z2,
-                Matrix::from_buffer([1, 0].map(R::from), 2, 1),
+                Matrix::from_buffer([0, 1].map(R::from), 2, 1),
             )
         );
     }
@@ -410,31 +410,31 @@ mod test {
     fn universal_morphism_out_medium() {
         type R = C<U12>;
         type I = CIdeal<U12>;
-        let z43 = Arc::new(CanonModule::<R, I>::from_iter([4, 3]));
-        let z32 = Arc::new(CanonModule::<R, I>::from_iter([3, 2]));
-        let z4332_canon = Arc::new(CanonModule::<R, I>::from_iter([4, 3, 3, 2]));
-        let z4332_direct = Object::sumproduct(&z32, &z43);
-        let univ_out = z4332_direct.universal_out(
+        let z34 = Arc::new(CanonModule::<R, I>::from_iter([4, 3]));
+        let z23 = Arc::new(CanonModule::<R, I>::from_iter([3, 2]));
+        let z2334_canon = Arc::new(CanonModule::<R, I>::from_iter([4, 3, 3, 2]));
+        let z2334_direct = Object::sumproduct(&z23, &z34);
+        let univ_out = z2334_direct.universal_out(
             &CanonToCanon::new(
-                &z32,
-                &z43,
+                &z23,
+                &z34,
                 Matrix::from_buffer([0, 2, 2, 0].map(R::from), 2, 2),
             ),
             &CanonToCanon::new(
-                &z43,
-                &z43,
-                Matrix::from_buffer([3, 0, 0, 1].map(R::from), 2, 2),
+                &z34,
+                &z34,
+                Matrix::from_buffer([1, 0, 0, 3].map(R::from), 2, 2),
             ),
         );
         let true_output_a = CanonToCanon::new(
-            &z4332_canon,
-            &z43,
-            Matrix::from_buffer([3, 0, 0, 2, 0, 2, 1, 0].map(R::from), 4, 2),
+            &z2334_canon,
+            &z34,
+            Matrix::from_buffer([0, 1, 2, 0, 2, 0, 0, 3].map(R::from), 4, 2),
         );
         let true_output_b = CanonToCanon::new(
-            &z4332_canon,
-            &z43,
-            Matrix::from_buffer([3, 0, 0, 2, 0, 1, 2, 0].map(R::from), 4, 2),
+            &z2334_canon,
+            &z34,
+            Matrix::from_buffer([1, 0, 0, 2, 2, 0, 0, 3].map(R::from), 4, 2),
         );
         // due to random id, one of those will be true
         assert!(univ_out == true_output_a || univ_out == true_output_b);
@@ -447,40 +447,40 @@ mod test {
         type I = CIdeal<U4>;
         let z2 = Arc::new(CanonModule::<R, I>::from_iter([2]));
         let z4 = Arc::new(CanonModule::<R, I>::from_iter([4]));
-        let z42_canon = Arc::new(CanonModule::<R, I>::from_iter([4, 2]));
-        let z42_direct = Object::sumproduct(&z2, &z4);
+        let z24_canon = Arc::new(CanonModule::<R, I>::from_iter([4, 2]));
+        let z24_direct = Object::sumproduct(&z4, &z2);
 
-        assert_eq!(z42_canon, z42_direct.module());
+        assert_eq!(z24_canon, z24_direct.module());
         assert_eq!(
-            z42_direct.left_inclusion,
+            z24_direct.right_inclusion,
             CanonToCanon::new(
                 &z2,
-                &z42_canon,
-                Matrix::from_buffer([0, 1].map(R::from), 1, 2),
-            )
-        );
-        assert_eq!(
-            z42_direct.right_inclusion,
-            CanonToCanon::new(
-                &z4,
-                &z42_canon,
+                &z24_canon,
                 Matrix::from_buffer([1, 0].map(R::from), 1, 2),
             )
         );
         assert_eq!(
-            z42_direct.left_projection,
+            z24_direct.left_inclusion,
             CanonToCanon::new(
-                &z42_canon,
-                &z2,
-                Matrix::from_buffer([0, 1].map(R::from), 2, 1),
+                &z4,
+                &z24_canon,
+                Matrix::from_buffer([0, 1].map(R::from), 1, 2),
             )
         );
         assert_eq!(
-            z42_direct.right_projection,
+            z24_direct.right_projection,
             CanonToCanon::new(
-                &z42_canon,
-                &z4,
+                &z24_canon,
+                &z2,
                 Matrix::from_buffer([1, 0].map(R::from), 2, 1),
+            )
+        );
+        assert_eq!(
+            z24_direct.left_projection,
+            CanonToCanon::new(
+                &z24_canon,
+                &z4,
+                Matrix::from_buffer([0, 1].map(R::from), 2, 1),
             )
         );
     }


### PR DESCRIPTION
odwrócony porządek sortowania modułów. wcześniej Z4xZ2, teraz Z2xZ4. niestety, ta zmiana była konieczna by się macierze porządnie smithowały. mam nadzieję, że nie będzie cię to kosztowało dużo pracy, sorka.